### PR TITLE
feat: support per-skillDirectory ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The CLI stores project settings in `skillz.json`. Here's a complete reference sh
   "skillDirectories": [
     {
       "localPath": ".claude/skills",
-      "include": ["python-expert", "react-patterns"]
+      "include": ["python-expert", "react-patterns"],
+      "ignore": ["experimental-*"]
     },
     {
       "localPath": "root-skill",
@@ -105,7 +106,7 @@ The CLI stores project settings in `skillz.json`. Here's a complete reference sh
   - Can be an empty array `[]` if only managing skills without syncing.
 - `skillDirectories` (SkillDirectory[]): Directories to scan for skills.
 - `additionalSkills` (string[]): Additional skill directories beyond `skillDirectories`. Can be empty `[]`.
-- `ignore` (string[]): Glob patterns to exclude skill directories (e.g., `["*.test", "experimental-*"]`). Can be empty `[]`.
+- `ignore` (string[]): Global glob patterns to exclude skill directories across all `skillDirectories` entries (e.g., `["*.test", "experimental-*"]`). Can be empty `[]`.
 
 **Optional Fields:**
 
@@ -141,6 +142,7 @@ The CLI stores project settings in `skillz.json`. Here's a complete reference sh
 - `remotePath` (string, optional): Remote source used by `skillz init --remote`.
 - `syncFromRoot` (boolean, optional): Treat the directory itself as a skill (must contain `SKILL.md`).
 - `include` (string[], optional): If set, only sync skills whose `name` matches one of these values.
+- `ignore` (string[], optional): Glob patterns to exclude subdirectories only for this skill directory entry.
 
 ### Sync Modes
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The CLI stores project settings in `skillz.json`. Here's a complete reference sh
   - Can be an empty array `[]` if only managing skills without syncing.
 - `skillDirectories` (SkillDirectory[]): Directories to scan for skills.
 - `additionalSkills` (string[]): Additional skill directories beyond `skillDirectories`. Can be empty `[]`.
-- `ignore` (string[]): Global glob patterns to exclude skill directories across all `skillDirectories` entries (e.g., `["*.test", "experimental-*"]`). Can be empty `[]`.
+- `ignore` (string[]): Global glob patterns to exclude skill directories across all `skillDirectories` entries (e.g., `["*.test", "experimental-*"]`). It can be empty (`[]`).
 
 **Optional Fields:**
 

--- a/notes/DESIGN.md
+++ b/notes/DESIGN.md
@@ -40,8 +40,8 @@ All targets use the same managed section format with skill links.
     { "destination": ".cursor/rules/skills.mdc" }
   ],
   "skillDirectories": [
-    ".claude/skills",
-    "~/.claude/skills"
+    { "localPath": ".claude/skills", "ignore": ["experimental-*"] },
+    { "localPath": "~/.claude/skills" }
   ],
   "additionalSkills": [
     "/custom/path/to/skills"
@@ -402,7 +402,7 @@ Skillz CLI keeps Claude-compatible skills synchronized across target documents s
 
 1. **CLI bootstrap** (`src/cli.ts`) wires commands and shared flags through Commander.
 2. **Configuration** (`src/core/config.ts`) loads or creates `skillz.json`, supplying a `Config` object to every command.
-3. **Skill discovery** (`src/core/skill-scanner.ts`) walks configured directories, applies glob-based ignore rules, and yields parsed `Skill` models.
+3. **Skill discovery** (`src/core/skill-scanner.ts`) walks configured directories, applies global plus per-directory glob ignore rules, and yields parsed `Skill` models.
 4. **Change detection & caching** (`src/core/change-detector.ts`, `src/core/cache-manager.ts`) compares current hashes to the last synced state to avoid unnecessary writes.
 5. **Rendering & target updates** (`src/core/template-engine.ts`, `src/core/target-manager.ts`) build Handlebars output and splice the managed section into each target file.
 6. **Persistence & feedback** leverage utilities in `src/utils/` for FS access, hashing, validation, and logging.
@@ -416,7 +416,7 @@ Skillz CLI keeps Claude-compatible skills synchronized across target documents s
 ### Core Services
 
 - **Configuration (`src/core/config.ts`)**: default presets, JSON persistence, and zod-backed validation.
-- **Skill Scanner (`src/core/skill-scanner.ts`)**: tilde expansion, directory listing, glob ignores via `minimatch`, and deduplication with warnings.
+- **Skill Scanner (`src/core/skill-scanner.ts`)**: tilde expansion, directory listing, global and per-directory glob ignores via `minimatch`, and deduplication with warnings.
 - **Skill Parser (`src/core/skill-parser.ts`)**: parses frontmatter through `gray-matter`, validates required fields, and produces deterministic hashes via `src/utils/hash.ts`.
 - **Template Engine (`src/core/template-engine.ts`)**: caches compiled Handlebars templates, prepares relative paths, and renders summaries or full instructions.
 - **Target Manager (`src/core/target-manager.ts`)**: reads/writes managed sections while preserving custom content.

--- a/src/core/skill-scanner.ts
+++ b/src/core/skill-scanner.ts
@@ -61,6 +61,7 @@ export async function scanAllSkillDirectories(config: Config): Promise<Skill[]> 
     const resolvedSkillDir = path.resolve(resolveHome(entry.localPath));
     let skillDirs: string[] = [];
     const includedNames = entry.include ? new Set(entry.include) : null;
+    const ignorePatterns = [...new Set([...(config.ignore ?? []), ...(entry.ignore ?? [])])];
 
     if (entry.syncFromRoot) {
       if (!(await isSkillDirectory(resolvedSkillDir))) {
@@ -70,7 +71,7 @@ export async function scanAllSkillDirectories(config: Config): Promise<Skill[]> 
       }
       skillDirs = [resolvedSkillDir];
     } else {
-      skillDirs = await scanDirectory(entry.localPath, config.ignore);
+      skillDirs = await scanDirectory(entry.localPath, ignorePatterns);
     }
 
     for (const skillDir of skillDirs) {

--- a/src/core/skill-scanner.ts
+++ b/src/core/skill-scanner.ts
@@ -61,7 +61,7 @@ export async function scanAllSkillDirectories(config: Config): Promise<Skill[]> 
     const resolvedSkillDir = path.resolve(resolveHome(entry.localPath));
     let skillDirs: string[] = [];
     const includedNames = entry.include ? new Set(entry.include) : null;
-    const ignorePatterns = [...new Set([...(config.ignore ?? []), ...(entry.ignore ?? [])])];
+    const ignorePatterns = [...new Set([...config.ignore, ...(entry.ignore ?? [])])];
 
     if (entry.syncFromRoot) {
       if (!(await isSkillDirectory(resolvedSkillDir))) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export interface SkillDirectory {
   remotePath?: string;
   syncFromRoot?: boolean;
   include?: string[];
+  ignore?: string[];
 }
 
 /**

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -25,6 +25,7 @@ export const ConfigSchema = z.object({
       remotePath: z.string().min(1).optional(),
       syncFromRoot: z.boolean().optional(),
       include: z.array(z.string()).optional(),
+      ignore: z.array(z.string()).optional(),
     })
   ),
   additionalSkills: z.array(z.string()),

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -172,6 +172,8 @@ description: Skill should still sync from second configured directory
     const agentsContent = await fs.readFile(workspace.agentsFile, 'utf-8');
     expect(agentsContent).not.toContain('sandbox-local');
     expect(agentsContent).toContain('sandbox-remote');
+    expect(agentsContent).toContain('python-expert');
+    expect(agentsContent).toContain('react-patterns');
   });
 
   it('should error when syncFromRoot skill directory lacks SKILL.md', async () => {

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -129,6 +129,51 @@ description: Skill used to verify *.test ignore patterns
     expect(agentsContent).not.toContain('sandbox-test');
   });
 
+  it('should apply ignore patterns per skillDirectory', async () => {
+    const localIgnoredDir = path.join(workspace.skillsDir, 'sandbox-local');
+    await fs.ensureDir(localIgnoredDir);
+    await fs.writeFile(
+      path.join(localIgnoredDir, 'SKILL.md'),
+      `---
+name: sandbox-local
+description: Skill ignored only in the first configured directory
+---
+`
+    );
+
+    const secondarySkillsDir = path.join(workspace.root, '.claude', 'more-skills');
+    const secondaryMatchingDir = path.join(secondarySkillsDir, 'sandbox-remote');
+    await fs.ensureDir(secondaryMatchingDir);
+    await fs.writeFile(
+      path.join(secondaryMatchingDir, 'SKILL.md'),
+      `---
+name: sandbox-remote
+description: Skill should still sync from second configured directory
+---
+`
+    );
+
+    const configPath = path.join(workspace.root, 'skillz.json');
+    const config = (await fs.readJson(configPath)) as Config;
+    config.ignore = [];
+    config.skillDirectories = [
+      { localPath: '.claude/skills', ignore: ['sandbox-*'] },
+      { localPath: '.claude/more-skills' },
+    ];
+    config.additionalSkills = [];
+    await fs.writeJson(configPath, config, { spaces: 2 });
+
+    const result = await execCli(['sync'], {
+      cwd: workspace.root,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const agentsContent = await fs.readFile(workspace.agentsFile, 'utf-8');
+    expect(agentsContent).not.toContain('sandbox-local');
+    expect(agentsContent).toContain('sandbox-remote');
+  });
+
   it('should error when syncFromRoot skill directory lacks SKILL.md', async () => {
     const configPath = path.join(workspace.root, 'skillz.json');
     const config = (await fs.readJson(configPath)) as Config;


### PR DESCRIPTION
feat: support per-skillDirectory ignore patterns

## Context
Adds scoped ignore support for individual entries in `skillDirectories` via `skillDirectories[].ignore`, while preserving existing top-level `ignore` behavior. Scanner applies global plus directory-specific ignore patterns for each configured directory.

Fixes: https://github.com/kevinslin/skillz/issues/7

## Testing
- [x] `npm run precommit`
- [x] `npm run test -- tests/integration/sync.test.ts -t "per skillDirectory"`
- [ ] Manual: configure two `skillDirectories`, set `ignore: ["sandbox-*"]` only on the first, and verify `sandbox-*` skills from the second directory still sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-skill-directory ignore patterns to exclude specific subdirectories for individual skill locations

* **Documentation**
  * Updated configuration documentation to clarify global vs per-directory ignore pattern scoping
  * Updated architecture documentation to reflect new ignore pattern model

* **Tests**
  * Added integration test validating per-directory ignore pattern behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->